### PR TITLE
Nested list syntax and typo fixes in Help.md

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -35,9 +35,9 @@ You must click the *Update Citations* button in the *Citations* <i class="icon-b
 1. Use the *Screen* <i class="icon-screen"></i> button to change between **editor**, **preview** and **dual** modes.
 1. Use the *Books* <i class="icon-books"></i> menu to **parse citation keys** such as [@Drake1991], to load a bibliography file, to see the loaded bibliography and the references you are citing.
 1. Use the *Download* <i class="icon-download-2"></i> menu to **download and convert** the Markdown text to various formats or to download a [Markdown] of the text or a [BibTeX] file of the citations referenced in the text.
-1. Click on **P** or **D** to **change the Markdown converter** between [Pandoc] and [Docverter]. 
-  - Pandoc: must be installed on local machine when working locally, can't process image URLs, slow conversion to PDF on Windows, requires *pdflatex* to convert to PDF on local machine.
- - Docverter: must be connected to the internet to be used, doesn't process citation keys and bibliography.
+1. Click on **P** or **D** to **change the Markdown converter** between [Pandoc] and [Docverter].
+    - Pandoc: must be installed on local machine when working locally, can't process image URLs, slow conversion to PDF on Windows, requires *pdflatex* to convert to PDF on local machine.
+    - Docverter: must be connected to the internet to be used, doesn't process citation keys and bibliography.
 1. Click the *Code* <i class="icon-code"></i> button to get change the **code highlighting styles**. Example code above.
 1. The grey boxes with the numbers display the **word and character counts**.
 

--- a/HELP.md
+++ b/HELP.md
@@ -10,7 +10,7 @@ Last update: 26 Feb 2013
 Markdown is very easy to learn and there are many online tutorials, just use Google.
 
 #### Markdown Flavor
-You should use **Pandoc-flavored Markdown** as both converters ([Pandoc] and [Docverter] use that). The HTML preview on the right is processed using [PageDown], so there could be some thing it doesn't process like Pandoc does (found something? open an [issue]).
+You should use **Pandoc-flavored Markdown** as both converters ([Pandoc] and [Docverter]) use that. The HTML preview on the right is processed using [PageDown], so there could be some thing it doesn't process like Pandoc does (found something? open an [issue]).
 
 #### Math
 You can use $LaTeX$. Just write it between `$`s or `\\(` and `\\)` for inline equations and `$$`s or `\\[` and `\\]` for display mode:
@@ -42,7 +42,7 @@ You must click the *Update Citations* button in the *Citations* <i class="icon-b
 1. The grey boxes with the numbers display the **word and character counts**.
 
 ### GitHub Integration
-**Your [GitHub] username and password are never sent to the Markx server**. They are sent by JavaScript to directly to the GitHub API server using [Github.js]. Your credentials are not saved in cookies and are removed from the browser memory as soon as the sign in is complete. You can also sign out of GitHub by clicking the *sign out* <i class="icon-exit"></i> button. If you would like to check the security of this feature please view the `signinToGithub` function in [markx.js] and open an [issue] if you find any problems.
+**Your [GitHub] username and password are never sent to the Markx server**. They are sent by JavaScript directly to the GitHub API server using [Github.js]. Your credentials are not saved in cookies and are removed from the browser memory as soon as the sign in is complete. You can also sign out of GitHub by clicking the *sign out* <i class="icon-exit"></i> button. If you would like to check the security of this feature please view the `signinToGithub` function in [markx.js] and open an [issue] if you find any problems.
 
 After you sign in to GitHub you can use the GitHub toolbar to:
 


### PR DESCRIPTION
Small typo corrections, and make nested list indentation in Toolbar section conform with pandoc's markown so that the export produces valid HTML (and other formats).

Current exported HTML:

```html
<h3 id="toolbar">Toolbar</h3>
<ol style="list-style-type: decimal">
<li>Use the <em>GitHub</em> <i class="icon-github-2"></i> button to <strong>sign-in to <a href="https://github.com/">GitHub</a></strong> (see more details below).</li>
<li>Use the <em>Screen</em> <i class="icon-screen"></i> button to change between <strong>editor</strong>, <strong>preview</strong> and <strong>dual</strong> modes.</li>
<li>Use the <em>Books</em> <i class="icon-books"></i> menu to <strong>parse citation keys</strong> such as [@Drake1991], to load a bibliography file, to see the loaded bibliography and the references you are citing.</li>
<li>Use the <em>Download</em> <i class="icon-download-2"></i> menu to <strong>download and convert</strong> the Markdown text to various formats or to download a <a href="http://daringfireball.net/projects/markdown/">Markdown</a> of the text or a <a href="http://www.bibtex.org/">BibTeX</a> file of the citations referenced in the text.</li>
<li>Click on <strong>P</strong> or <strong>D</strong> to <strong>change the Markdown converter</strong> between <a href="http://johnmacfarlane.net/pandoc">Pandoc</a> and <a href="http://www.docverter.com/">Docverter</a>.</li>
</ol>
<ul>
<li>Pandoc: must be installed on local machine when working locally, can't process image URLs, slow conversion to PDF on Windows, requires <em>pdflatex</em> to convert to PDF on local machine.</li>
<li>Docverter: must be connected to the internet to be used, doesn't process citation keys and bibliography.</li>
</ul>
<ol style="list-style-type: decimal">
<li>Click the <em>Code</em> <i class="icon-code"></i> button to get change the <strong>code highlighting styles</strong>. Example code above.</li>
<li>The grey boxes with the numbers display the <strong>word and character counts</strong>.</li>
</ol>
```
(shows as a new, not nested bullet list)

After indentation fix:

```html
<h3 id="toolbar">Toolbar</h3>
<ol style="list-style-type: decimal">
<li>Use the <em>GitHub</em> <i class="icon-github-2"></i> button to <strong>sign-in to <a href="https://github.com/">GitHub</a></strong> (see more details below).</li>
<li>Use the <em>Screen</em> <i class="icon-screen"></i> button to change between <strong>editor</strong>, <strong>preview</strong> and <strong>dual</strong> modes.</li>
<li>Use the <em>Books</em> <i class="icon-books"></i> menu to <strong>parse citation keys</strong> such as [@Drake1991], to load a bibliography file, to see the loaded bibliography and the references you are citing.</li>
<li>Use the <em>Download</em> <i class="icon-download-2"></i> menu to <strong>download and convert</strong> the Markdown text to various formats or to download a <a href="http://daringfireball.net/projects/markdown/">Markdown</a> of the text or a <a href="http://www.bibtex.org/">BibTeX</a> file of the citations referenced in the text.</li>
<li>Click on <strong>P</strong> or <strong>D</strong> to <strong>change the Markdown converter</strong> between <a href="http://johnmacfarlane.net/pandoc">Pandoc</a> and <a href="http://www.docverter.com/">Docverter</a>.
<ul>
<li>Pandoc: must be installed on local machine when working locally, can't process image URLs, slow conversion to PDF on Windows, requires <em>pdflatex</em> to convert to PDF on local machine.</li>
<li>Docverter: must be connected to the internet to be used, doesn't process citation keys and bibliography.</li>
</ul></li>
<li>Click the <em>Code</em> <i class="icon-code"></i> button to get change the <strong>code highlighting styles</strong>. Example code above.</li>
<li>The grey boxes with the numbers display the <strong>word and character counts</strong>.</li>
</ol>
```

Thanks a lot for Markx, it is a great, useful tool!